### PR TITLE
Fixed some issues noticed investigating #9.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+.gradle/
+build/
+out/

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -1,0 +1,21 @@
+<p>This extension can be used to generate and fuzz custom AMF messages.
+It is designed and implemented to make AMF testing easy, and yet allows researchers to control fully the entire security testing process.</p>
+
+<p>Blazer implements a new testing approach, introduced at Black Hat USA 2012.
+This automated gray-box testing technique allows security researchers to improve the coverage and the effectiveness of fuzzing efforts targeting complex applications.</p>
+
+<p>Features include:</p>
+<ul>
+    <li>Automatic Java objects generation from method signatures via Java reflection and "best-fit" heuristics</li>
+    <li>Fuzzing capabilities, with customizable data pools and attack vectors</li>
+    <li>Ability to start, pause, restore and stop testing</li>
+    <li>Easy-to-use internal methods to construct custom AMF messages</li>
+    <li>Embedded BeanShell for manual testing</li>
+    <li>Highly integrated in Burp Suite</li>
+    <li>JARs, classes and Java src import feature</li>
+    <li>AMF request/response export functionality (AMF2XML)</li>
+    <li>Sandbox feature using a custom security manager</li>
+    <li>Support for Java server-side remoting technologies (Adobe BlazeDS, Adobe LiveCycle Data Services, GraniteDS, ...)</li>
+</ul>
+
+

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,7 +1,7 @@
 Uuid: 7c385950b7e84257ad5d3338bb5882b4
 ExtensionType: 1
 Name: Blazer
-ScreenVersion: 0.4
+ScreenVersion: 0.3
 SerialVersion: 2
 MinPlatformVersion: 0
 ProOnly: False

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,7 +2,7 @@ Uuid: 7c385950b7e84257ad5d3338bb5882b4
 ExtensionType: 1
 Name: Blazer
 ScreenVersion: 0.3
-SerialVersion: 2
+SerialVersion: 3
 MinPlatformVersion: 0
 ProOnly: False
 Author: Luca Carettoni

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -8,4 +8,4 @@ ProOnly: False
 Author: Luca Carettoni
 ShortDescription: Generates and fuzzes custom AMF messages.
 EntryPoint: build/libs/blazer-all.jar
-BuildCommand: gradle -PburpJar=$BURP_JAR fatJar
+BuildCommand: gradle fatJar

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,7 +2,7 @@ Uuid: 7c385950b7e84257ad5d3338bb5882b4
 ExtensionType: 1
 Name: Blazer
 ScreenVersion: 0.4
-SerialVersion: 1
+SerialVersion: 2
 MinPlatformVersion: 0
 ProOnly: False
 Author: Luca Carettoni

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,7 +1,7 @@
 Uuid: 7c385950b7e84257ad5d3338bb5882b4
 ExtensionType: 1
 Name: Blazer
-ScreenVersion: 0.3
+ScreenVersion: 0.4
 SerialVersion: 1
 MinPlatformVersion: 0
 ProOnly: False

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,6 +1,7 @@
 Uuid: 7c385950b7e84257ad5d3338bb5882b4
 ExtensionType: 1
 Name: Blazer
+RepoName: blazer
 ScreenVersion: 0.3
 SerialVersion: 4
 MinPlatformVersion: 0

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,7 +2,7 @@ Uuid: 7c385950b7e84257ad5d3338bb5882b4
 ExtensionType: 1
 Name: Blazer
 ScreenVersion: 0.3
-SerialVersion: 3
+SerialVersion: 4
 MinPlatformVersion: 0
 ProOnly: False
 Author: Luca Carettoni

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,0 +1,11 @@
+Uuid: 7c385950b7e84257ad5d3338bb5882b4
+ExtensionType: 1
+Name: Blazer
+ScreenVersion: 0.3
+SerialVersion: 1
+MinPlatformVersion: 0
+ProOnly: False
+Author: Luca Carettoni
+ShortDescription: Generates and fuzzes custom AMF messages.
+EntryPoint: build/libs/blazer-all.jar
+BuildCommand: gradle -PburpJar=$BURP_JAR fatJar

--- a/build.gradle
+++ b/build.gradle
@@ -24,5 +24,7 @@ sourceSets {
 task fatJar(type: Jar) {
     baseName = project.name + '-all'
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    exclude('META-INF/*.RSA')
+    exclude('META-INF/*.SF')
     with jar
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,28 @@
+apply plugin: 'java'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile files("$burpJar")
+    compile 'com.thoughtworks.xstream:xstream:1.4.9'
+    compile 'org.apache.flex.blazeds:flex-messaging-core:4.7.2'
+    compile 'com.github.javaparser:javaparser-core:2.5.1'
+    compile 'org.eclipse.jetty.orbit:org.objectweb.asm:3.3.1.v201105211655'
+    compile 'bsh:bsh:2.0b4'
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src'
+        }
+    }
+}
+
+task fatJar(type: Jar) {
+    baseName = project.name + '-all'
+    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'java'
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories {
     mavenCentral()
@@ -11,6 +13,7 @@ dependencies {
     compile 'com.github.javaparser:javaparser-core:2.5.1'
     compile 'org.eclipse.jetty.orbit:org.objectweb.asm:3.3.1.v201105211655'
     compile 'bsh:bsh:2.0b4'
+    compile 'com.google.code.gson:gson:2.8.5'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-    compile files("$burpJar")
+    compile 'net.portswigger.burp.extender:burp-extender-api:1.7.13'
     compile 'com.thoughtworks.xstream:xstream:1.4.9'
     compile 'org.apache.flex.blazeds:flex-messaging-core:4.7.2'
     compile 'com.github.javaparser:javaparser-core:2.5.1'

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ sourceSets {
         java {
             srcDir 'src'
         }
+        resources {
+            srcDir 'src'
+            exclude '**.java'
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'blazer'

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -91,6 +91,8 @@ class CustomMenuItem implements IMenuItemHandler {
     }
 
     public void menuItemClicked(String menuItemCaption, IHttpRequestResponse[] messageInfo) {
+        if (messageInfo[0].getRequest() == null) return;
+
         try {
             // User clicked on the Blazer extension contextual menu
             if (menuItemCaption.equalsIgnoreCase("Blazer - AMF Testing")) { //Standard Blazer GUI

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -156,18 +156,6 @@ class CustomMenuItem implements IMenuItemHandler {
     private BlazerUIView initializeAndDisplay(IHttpRequestResponse[] messageInfo) throws Exception {
         manager = new TaskManager(callbacks, messageInfo);
 
-        try {
-            for (LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
-                if ("Nimbus".equals(info.getName())) {
-                    UIManager.setLookAndFeel(info.getClassName());
-                    break;
-                }
-            }
-        } catch (Exception e) {
-            // Nimbus L&F is not available, set the GUI to Metal or whatever is available
-            UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
-        }
-
         return new BlazerUIView(manager);
     }
 }

--- a/src/com/mtso/blazer/Exporter.java
+++ b/src/com/mtso/blazer/Exporter.java
@@ -105,9 +105,9 @@ public class Exporter {
 
         for (IHttpRequestResponse singleMsg : messageInfo) {
             //Request or Response details
-            reqsDet.append("Host:").append(singleMsg.getHost()).append(System.getProperty("line.separator"));
-            reqsDet.append("Port:").append(singleMsg.getPort()).append(System.getProperty("line.separator"));
-            reqsDet.append("Protocol:").append(singleMsg.getProtocol()).append(System.getProperty("line.separator"));
+            reqsDet.append("Host:").append(singleMsg.getHttpService().getHost()).append(System.getProperty("line.separator"));
+            reqsDet.append("Port:").append(singleMsg.getHttpService().getPort()).append(System.getProperty("line.separator"));
+            reqsDet.append("Protocol:").append(singleMsg.getHttpService().getProtocol()).append(System.getProperty("line.separator"));
             reqsDet.append("Comment:").append(singleMsg.getComment()).append(System.getProperty("line.separator"));
             if (exportRequests) {
                 reqsDet.append("HTTP Request:").append(System.getProperty("line.separator")).append(xstream.toXML(AMFUtil.extractAM(singleMsg.getRequest(), manager.getStdOut(), manager.getStdErr())).replaceAll("\n", System.getProperty("line.separator"))).append(System.getProperty("line.separator"));

--- a/src/com/mtso/blazer/JavaUtil.java
+++ b/src/com/mtso/blazer/JavaUtil.java
@@ -14,15 +14,15 @@
  */
 package com.mtso.blazer;
 
-import japa.parser.JavaParser;
-import japa.parser.ast.CompilationUnit;
-import japa.parser.ast.ImportDeclaration;
-import japa.parser.ast.body.BodyDeclaration;
-import japa.parser.ast.body.ClassOrInterfaceDeclaration;
-import japa.parser.ast.body.MethodDeclaration;
-import japa.parser.ast.body.ModifierSet;
-import japa.parser.ast.body.Parameter;
-import japa.parser.ast.body.TypeDeclaration;
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.ModifierSet;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;

--- a/src/com/mtso/blazer/TaskManager.java
+++ b/src/com/mtso/blazer/TaskManager.java
@@ -76,7 +76,7 @@ public class TaskManager implements ThreadCompleteListener {
         currentTask.setProxyHost(proxySettings[0]);
         currentTask.setProxyPort(proxySettings[1]);
         currentTask.setCookies(GenericUtil.getCookies(this.requestResponse.getRequest()));
-        currentTask.setEndpoint(this.requestResponse.getUrl().toString());
+        currentTask.setEndpoint(this.burpCallbacks.getHelpers().analyzeRequest(this.requestResponse).getUrl().toString());
     }
 
     public PrintWriter getStdOut() {

--- a/src/com/mtso/blazer/TaskManager.java
+++ b/src/com/mtso/blazer/TaskManager.java
@@ -46,15 +46,17 @@ public class TaskManager implements ThreadCompleteListener {
     private long startTime = 0;
 
     public TaskManager(IBurpExtenderCallbacks burpCallbacks, IHttpRequestResponse[] requestResponse) throws Exception {
-
-        Float majorVer = new Float(burpCallbacks.getBurpVersion()[1]);
-        Float minorVer = new Float(0);
-        if (burpCallbacks.getBurpVersion()[2] != null && !burpCallbacks.getBurpVersion()[2].isEmpty()) {
-            minorVer = new Float(burpCallbacks.getBurpVersion()[2]);
+        String[] version = burpCallbacks.getBurpVersion();
+        Float majorVer = Float.parseFloat(version[1]);
+        Float minorVer = 0f;
+        if (version.length == 3 && !version[2].isEmpty()) {
+            String minor = version[2];
+            // Remove all non-numeric characters from the minor version, particularly for the new beta builds.
+            minorVer = Float.parseFloat(minor.replaceAll("[^\\d]+", ""));
         }
 
-        //If running Burp Suite >= [Burp Suite Professional][1.5].[01], enable custom Stdout and Stderr       
-        if (majorVer >= 1.5 && minorVer >= 1.0) {
+        //If running Burp Suite >= [Burp Suite Professional][1.5].[01], enable custom Stdout and Stderr
+        if (majorVer > 1.5 || (majorVer == 1.5 && minorVer >= 1.0)) {
             //new registerExtenderCallbacks interface
             burpCallbacks.setExtensionName(BurpExtender.getBanner());
             stdout = new PrintWriter(burpCallbacks.getStdout(), true);
@@ -72,7 +74,13 @@ public class TaskManager implements ThreadCompleteListener {
         pcs = new PropertyChangeSupport(this);
 
         currentTask = new TaskSpecification(this.getStdOut(), this.getStdErr());
-        String[] proxySettings = GenericUtil.burpProxySettings(burpCallbacks.saveConfig()).split(":");
+        String[] proxySettings;
+        if (majorVer > 1.7) {
+            proxySettings = GenericUtil.burpProxySettings(
+                    burpCallbacks.saveConfigAsJson("proxy.request_listeners")).split(":");
+        } else {
+            proxySettings = GenericUtil.burpProxySettings(burpCallbacks.saveConfig()).split(":");
+        }
         currentTask.setProxyHost(proxySettings[0]);
         currentTask.setProxyPort(proxySettings[1]);
         currentTask.setCookies(GenericUtil.getCookies(this.requestResponse.getRequest()));


### PR DESCRIPTION
Resolved issues with the `IBurpExtenderCallbacks.getBurpVersion()` including `beta` for the new 2.0 beta versions. Also changed the config for Burp versions greater than `1.7` to use `IBurpExtenderCallbacks.saveConfigAsJson` since the other call was [deprecated a while ago](https://github.com/PortSwigger/burp-extender-api/commit/8a540cbf28f52701a2c714c0e81bd2f9a87bcf1f#diff-d4910b05bbbb48649c0218f84cf6e600R889), at least since January 2017. 